### PR TITLE
feat: Dismiss Job Cancelled in SD

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class JenkinsExecutor extends Executor {
             params: [{ name: jobName }]
         });
 
-        if (!job || (!job.inQueue && !(job.lastBuild && job.lastBuild.number))) {
+        if (!job) {
             throw new Error('No build has been started yet, try later');
         }
         

--- a/index.js
+++ b/index.js
@@ -70,17 +70,18 @@ class JenkinsExecutor extends Executor {
             params: [{ name: jobName }]
         });
 
-        if (!(job && job.lastBuild && job.lastBuild.number)) {
+        if (!job || !(job.inQueue && job.lastBuild && job.lastBuild.number)) {
             throw new Error('No build has been started yet, try later');
         }
-
-        await this.breaker.runCommand({
-            module: 'build',
-            action: 'stop',
-            params: [{ name: jobName, number: job.lastBuild.number }]
-        });
-
-        return this._jenkinsJobWaitStop(jobName, 0);
+        
+        if (!job.inQueue) {
+            await this.breaker.runCommand({
+                module: 'build',
+                action: 'stop',
+                params: [{ name: jobName, number: job.lastBuild.number }]
+            });
+            return this._jenkinsJobWaitStop(jobName, 0);
+        }
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -81,6 +81,12 @@ class JenkinsExecutor extends Executor {
                 params: [{ name: jobName, number: job.lastBuild.number }]
             });
             return this._jenkinsJobWaitStop(jobName, 0);
+        } else {
+            await this.breaker.runCommand({
+                 module: 'queue',
+                 action: 'cancel',
+                 params: [{ number: job.queueItem.id }],
+            });
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class JenkinsExecutor extends Executor {
             params: [{ name: jobName }]
         });
 
-        if (!job || !(job.inQueue && job.lastBuild && job.lastBuild.number)) {
+        if (!job || (!job.inQueue && !(job.lastBuild && job.lastBuild.number))) {
             throw new Error('No build has been started yet, try later');
         }
         

--- a/index.js
+++ b/index.js
@@ -71,22 +71,24 @@ class JenkinsExecutor extends Executor {
         });
 
         if (!job) {
-            throw new Error('No build has been started yet, try later');
+            throw new Error('No jobs in process yet, try later');
         }
         
         if (job.inQueue) {
-            await this.breaker.runCommand({
+            return await this.breaker.runCommand({
                  module: 'queue',
                  action: 'cancel',
                  params: [{ number: job.queueItem.id }],
             });
-        } else {
+        }
+        
+        if (job.lastBuild && job.lastBuild.number) {
             await this.breaker.runCommand({
                 module: 'build',
                 action: 'stop',
                 params: [{ name: jobName, number: job.lastBuild.number }]
             });
-            return this._jenkinsJobWaitStop(jobName, 0);
+            return await this._jenkinsJobWaitStop(jobName, 0);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -74,19 +74,19 @@ class JenkinsExecutor extends Executor {
             throw new Error('No build has been started yet, try later');
         }
         
-        if (!job.inQueue) {
+        if (job.inQueue) {
+            await this.breaker.runCommand({
+                 module: 'queue',
+                 action: 'cancel',
+                 params: [{ number: job.queueItem.id }],
+            });
+        } else {
             await this.breaker.runCommand({
                 module: 'build',
                 action: 'stop',
                 params: [{ name: jobName, number: job.lastBuild.number }]
             });
             return this._jenkinsJobWaitStop(jobName, 0);
-        } else {
-            await this.breaker.runCommand({
-                 module: 'queue',
-                 action: 'cancel',
-                 params: [{ number: job.queueItem.id }],
-            });
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -74,21 +74,19 @@ class JenkinsExecutor extends Executor {
             throw new Error('No jobs in process yet, try later');
         }
         
-        if (job.inQueue) {
-            return await this.breaker.runCommand({
+        if (job.inQueue && job.queueItem && job.queueItem.id ) {
+            await this.breaker.runCommand({
                  module: 'queue',
                  action: 'cancel',
                  params: [{ number: job.queueItem.id }],
             });
-        }
-        
-        if (job.lastBuild && job.lastBuild.number) {
+        } else if (job.lastBuild && job.lastBuild.number) {
             await this.breaker.runCommand({
                 module: 'build',
                 action: 'stop',
                 params: [{ name: jobName, number: job.lastBuild.number }]
             });
-            return await this._jenkinsJobWaitStop(jobName, 0);
+            await this._jenkinsJobWaitStop(jobName, 0);
         }
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -403,7 +403,8 @@ describe('index', () => {
 
         it('return error when there is no build to be stopped yet', (done) => {
             const noBuildJobInfo = {
-                lastBuild: null
+                lastBuild: null,
+                inQueue: false
             };
 
             breakerMock.runCommand.withArgs(getOpts).resolves(noBuildJobInfo);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -402,12 +402,7 @@ describe('index', () => {
         });
 
         it('return error when there is no build to be stopped yet', (done) => {
-            const noBuildJobInfo = {
-                lastBuild: null,
-                inQueue: false
-            };
-
-            breakerMock.runCommand.withArgs(getOpts).resolves(noBuildJobInfo);
+            breakerMock.runCommand.withArgs(getOpts).resolves(null);
             breakerMock.runCommand.withArgs(stopOpts).resolves(null);
 
             executor.stop({ buildId: config.buildId }).catch((err) => {


### PR DESCRIPTION
### Context 

For now, a single job in the Jenkins queue is not dismissed although the job has actually been cancelled in screwdriver-cd. 
This attribute induces accumulation of the Jenkins queue, especially for the pipelines which have many jobs defined.

### Objective

Jobs cancelled in the screwdriver-cd interface would also be deleted from the queue list of the Jenkins.